### PR TITLE
Radish 2.02

### DIFF
--- a/python/version.py
+++ b/python/version.py
@@ -1,1 +1,1 @@
-firmware_version = "Radish 2.01"
+firmware_version = "Radish 2.02"

--- a/setup/MV1_firmware_cron.txt
+++ b/setup/MV1_firmware_cron.txt
@@ -55,7 +55,7 @@ LOG_PATH=/home/pi/Desktop/MV1_firmware/logs
 */5 * * * * sudo bash $SCRIPT_PATH/network_check.sh >> $LOG_PATH/network_check.log 2>&1 &
 
 # Update the device and reboot at 2:30AM every day
-30 2 * * * sudo bash $SCRIPT_PATH/local_update.sh >> $LOG_PATH/local_update.log 2>&1 &
+30 2 * * * bash $SCRIPT_PATH/local_update.sh >> $LOG_PATH/local_update.log 2>&1 &
 
 # Back up any images not sent to S3 overnight, at 3:30AM every day
 30 3 * * * python3 $PYTHON_PATH/ImageBackup.py >> $LOG_PATH/S3_backup.log 2>&1 &


### PR DESCRIPTION
Bug Fix: Running "local_update.sh" as sudo via Cron caused there to be two separate executions of Cron running, meaning that sensors were logging twice, and possibly causing the heating that kept the heater running constantly.