### PR TITLE
Radish 2.04

### DIFF
--- a/python/CameraAF.py
+++ b/python/CameraAF.py
@@ -23,7 +23,7 @@ sleep(2)
 #Take picture
 file_name = time + '.jpg' # construct the file name using the current time 
 print('image will be saved to: ', IMAGE_DIR + file_name) 
-cmd = '/usr/local/bin/libcamera-still -t 5000 --nopreview --width 1920 --height 1080 --continue-autofocus --awb incandescent -o {}'.format(IMAGE_DIR + file_name)
+cmd = '/usr/local/bin/libcamera-still -t 5000 --nopreview --width 1920 --height 1080 --continue-autofocus --awbgains 1.2,3.0 -o {}'.format(IMAGE_DIR + file_name)
 # construct the commad to capture the image using the libcamera-still command-line utility 
 os.system(cmd)
 sleep(10)

--- a/python/version.py
+++ b/python/version.py
@@ -1,1 +1,1 @@
-firmware_version = "Radish 2.03"
+firmware_version = "Radish 2.04"


### PR DESCRIPTION
Final camera tuning, the "incandescent" mode of AWB still had too great of a range for consistent photos. The "--awbgains" mode should keep the image colors consistent, effectively turning off any auto-tuning of the images by the firmware.